### PR TITLE
Allow LibreAutomate documentation to be served locally using "docfx serve"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,15 @@ ModelManifest.xml
 *.bak
 /Au/global.json
 .tools/
+
+# LibreAutomate compiliation of docs
+/LA.Workspace.For.Scripts/*
+!/LA.Workspace.For.Scripts/readme.txt
+!/LA.Workspace.For.Scripts/files.xml
+!/LA.Workspace.For.Scripts/state.db
+!/LA.Workspace.For.Scripts/files/
+
+# Documentation generation
+/Other/DocFx/_doc/cookbook/*
+/Other/DocPreProcessed/*
+/Other/DocFxProcessed/*

--- a/Au.Editor/App/AppSettings.cs
+++ b/Au.Editor/App/AppSettings.cs
@@ -18,6 +18,7 @@ record AppSettings : JSettings {
 		(font_recipeText ??= new()).Normalize("Calibri", 10.5);
 		(font_recipeCode ??= new()).Normalize("Consolas", 9);
 		(font_find ??= new()).Normalize("Consolas", 9);
+		DOptions.PushLocalDocOptionsToHelpUtils(this);
 		debug ??= new();
 		delm ??= new();
 		recorder ??= new();
@@ -98,9 +99,15 @@ record AppSettings : JSettings {
 	//Options > Other
 	public bool? comp_printCompiled = false;
 	public string internetSearchUrl = "https://www.google.com/search?q=";
-	
-	//code editor
-	public bool edit_wrap, edit_noImages;
+
+	//Options > Docs
+	public bool enableLocalDocumentation;
+    public string documentationDir = HelpUtil.stdDocumentationDir;
+	public string docFxExecutable = HelpUtil.stdDocFxExecutable;
+    public string docFxPort = HelpUtil.stdDocFxPort;
+
+    //code editor
+    public bool edit_wrap, edit_noImages;
 	public string edit_theme;
 	
 	//code info, autocorrection, formatting

--- a/Au.Editor/App/Menus.cs
+++ b/Au.Editor/App/Menus.cs
@@ -565,7 +565,7 @@ static class Menus {
 	[Command(target = "")]
 	public static class Help {
 		[Command(image = "*Modern.Home" + blue)]
-		public static void Website() { HelpUtil.AuHelp(""); }
+		public static void Website() { HelpUtil.AuHelp("", true); }
 		
 		[Command(image = "*BoxIcons.RegularLibrary" + darkYellow)]
 		public static void Library_help() { HelpUtil.AuHelp("api/"); }

--- a/Au/Au.More/HelpUtil.cs
+++ b/Au/Au.More/HelpUtil.cs
@@ -1,3 +1,5 @@
+using System.Security.Policy;
+
 namespace Au.More
 {
 	/// <summary>
@@ -6,11 +8,41 @@ namespace Au.More
 	public static class HelpUtil
 	{
 		/// <summary>
-		/// Opens an Au library help topic online.
+		/// Determines whether local rather than online documentation is shown for calls to <see cref="Au.More.HelpUtil.AuHelp(string)"/>.
 		/// </summary>
-		/// <param name="topic">Topic file name, like <c>"Au.wnd.find"</c> or <c>"wnd.find"</c> or <c>"articles/Wildcard expression"</c>.</param>
-		public static void AuHelp(string topic) {
-			run.itSafe(AuHelpUrl(topic));
+		public static bool enableLocalDocumentation;
+		/// <summary>
+		/// Directory where local documentation is found.  Defaults to <see cref="Au.More.HelpUtil.stdDocumentationDir"/>.
+		/// </summary>
+		public static string documentationDir;
+        /// <summary>
+        /// Usual directory where local documentation is found.  Set to <c>\docs</c> in the folder <see cref="Au.folders.Editor"/> at runtime.
+        /// </summary>
+        public static readonly string stdDocumentationDir = folders.Editor + @"\docs";
+        /// <summary>
+        /// Full path to <c>docfx.exe</c>.  Defaults to <see cref="Au.More.HelpUtil.stdDocFxExecutable"/>.
+        /// </summary>
+        public static string docFxExecutable;
+        /// <summary>
+        /// Usual full path to <c>docfx.exe</c>.  Set to <c>\.dotnet\tools\docfx.exe</c> in the folder <see cref="Au.folders.Profile"/> at runtime.
+        /// </summary>
+        public static readonly string stdDocFxExecutable = folders.Profile + @"\.dotnet\tools\docfx.exe";
+        /// <summary>
+        /// Port number used by docfx to serve the local documentation.  Passed as <c>--port</c> parameter.  Defaults to <see cref="Au.More.HelpUtil.stdDocFxPort"/>.
+        /// </summary>
+        public static string docFxPort;
+        /// <summary>
+        /// Usual port number to pass to docfx to serve the local documentation.  Passed as <c>--port</c> parameter.  Set to <c>8080</c>.
+        /// </summary>
+        public static readonly string stdDocFxPort = "8080";
+
+        /// <summary>
+        /// Opens an Au library help topic.  If <see cref="Au.More.HelpUtil.enableLocalDocumentation"/> is false then help is obtained from <b>https://www.libreautomate.com/</b>.
+		/// Otherwise docfx.exe is called using the path <see cref="Au.More.HelpUtil.docFxExecutable"/> with the <c>serve</c> command and the <c>--port</c> parameter and help is obtained from the url <b>http://localhost:port"/</b> where <b>port</b> is <see cref="Au.More.HelpUtil.docFxPort"/>.
+        /// </summary>
+        /// <param name="topic">Topic file name, like <c>"Au.wnd.find"</c> or <c>"wnd.find"</c> or <c>"articles/Wildcard expression"</c>.</param>
+        public static void AuHelp(string topic) {
+            run.itSafe(AuHelpUrl(topic));
 		}
 
 		/// <summary>
@@ -18,13 +50,48 @@ namespace Au.More
 		/// </summary>
 		/// <param name="topic">Topic file name, like <c>"Au.wnd.find"</c> or <c>"wnd.find"</c> or <c>"articles/Wildcard expression"</c>.</param>
 		public static string AuHelpUrl(string topic) {
+			string url;
 			if (topic.Ends(".this[]")) topic = topic.ReplaceAt(^7.., ".Item");
 			else if (topic.Ends(".this")) topic = topic.ReplaceAt(^5.., ".Item");
 			else if (topic.Ends("[]")) topic = topic.ReplaceAt(^2.., ".Item");
 
-			var url = "https://www.libreautomate.com/";
-			if (!topic.NE()) url = url + (topic.Contains('/') ? null : (topic.Starts("Au.") ? "api/" : "api/Au.")) + topic + (topic.Ends('/') || topic.Ends(".html") ? null : ".html");
+            if (enableLocalDocumentation)
+			{
+                LaunchLocalDocFxServer();
+                url = @"http://localhost:" + docFxPort + @"/";
+			}
+            else 
+            {
+                url = "https://www.libreautomate.com/";
+            }
+            if (!topic.NE()) url = url + (topic.Contains('/') ? null : (topic.Starts("Au.") ? "api/" : "api/Au.")) + topic + (topic.Ends('/') || topic.Ends(".html") ? null : ".html");
 			return url;
 		}
-	}
+        /// <summary>
+        /// Launches DocFx.exe server if it is not already running and creates an event handler to close it when this process exits.
+        /// </summary>
+        private static void LaunchLocalDocFxServer()
+        {
+            documentationDir ??= stdDocumentationDir;
+            docFxPort ??= stdDocFxPort;
+            string cmdLine = $@"serve ""{documentationDir}"" --port {docFxPort}";
+            foreach (int pidInLoop in process.getProcessIds("docfx.exe"))
+            {
+                if (string.Equals(process.getCommandLine(pidInLoop, true), cmdLine)) return;
+            }
+
+            docFxExecutable ??= stdDocFxExecutable;
+            RResult rresult = run.it(docFxExecutable, cmdLine, flags: RFlags.InheritAdmin, dirEtc: new() { WindowState = ProcessWindowStyle.Hidden });
+            var pid = rresult.ProcessId;
+            process.getTimes(pid, out long created, out long _);
+
+            process.thisProcessExit += (Exception ex) =>
+            {
+                if (process.getTimes(pid, out long createdInEventHandler, out long _))
+                {
+                    if (created == createdInEventHandler) process.terminate(pid);
+                }
+            };
+        }
+    }
 }

--- a/Au/Au.More/HelpUtil.cs
+++ b/Au/Au.More/HelpUtil.cs
@@ -41,22 +41,22 @@ namespace Au.More
 		/// Otherwise docfx.exe is called using the path <see cref="Au.More.HelpUtil.docFxExecutable"/> with the <c>serve</c> command and the <c>--port</c> parameter and help is obtained from the url <b>http://localhost:port"/</b> where <b>port</b> is <see cref="Au.More.HelpUtil.docFxPort"/>.
         /// </summary>
         /// <param name="topic">Topic file name, like <c>"Au.wnd.find"</c> or <c>"wnd.find"</c> or <c>"articles/Wildcard expression"</c>.</param>
-        public static void AuHelp(string topic) {
-            run.itSafe(AuHelpUrl(topic));
+        public static void AuHelp(string topic, bool forceNonLocalDocumentation = false) {
+            run.itSafe(AuHelpUrl(topic, forceNonLocalDocumentation));
 		}
 
 		/// <summary>
 		/// Gets URL of an Au library help topic.
 		/// </summary>
 		/// <param name="topic">Topic file name, like <c>"Au.wnd.find"</c> or <c>"wnd.find"</c> or <c>"articles/Wildcard expression"</c>.</param>
-		public static string AuHelpUrl(string topic) {
+		public static string AuHelpUrl(string topic, bool forceNonLocalDocumentation = false) {
 			string url;
 			if (topic.Ends(".this[]")) topic = topic.ReplaceAt(^7.., ".Item");
 			else if (topic.Ends(".this")) topic = topic.ReplaceAt(^5.., ".Item");
 			else if (topic.Ends("[]")) topic = topic.ReplaceAt(^2.., ".Item");
 
-            if (enableLocalDocumentation)
-			{
+            if (enableLocalDocumentation && !forceNonLocalDocumentation)
+            {
                 LaunchLocalDocFxServer();
                 url = @"http://localhost:" + docFxPort + @"/";
 			}

--- a/LA.Workspace.For.Scripts/Readme.txt
+++ b/LA.Workspace.For.Scripts/Readme.txt
@@ -1,0 +1,19 @@
+This is for creating docs which is done within working LibraAutomate (LA) environment
+
+Setup the LA workspace
+1.  Edit files.xml in this directory.  Change the Scripts path in line 3 to the absolute path to the scripts directory.  
+	The relative path from this readme file is ..\Scripts but the absolute path will depend 
+	upon the name and location of your repository for LA
+2.  Build LA --> Install LA --> Run LA
+3.	Within LA, Open the workspace whose relative path from this readme file is ..\LA.Workspace.For.Scripts
+	(LA menu --> File --> workspace --> open workspace
+
+Build the docs
+	From LA run the script @Au docs --> Au docs.  This will run the _Build function.  See the documentation for that function for further details.
+	If starting from nothing, need to enable the booleans cookbook, preprocess, docFxBuild, and postprocess.
+
+To use the docs
+	Copy the docs created in the previous step to their final destination.  Expected location is \Program files\LibreAutomate\Docs.
+	Download the program DocFx.exe which requries the .NET SDK
+	Turn on location documentation From LA --> tools --> options.  May need to modify the default location
+	

--- a/LA.Workspace.For.Scripts/files.xml
+++ b/LA.Workspace.For.Scripts/files.xml
@@ -1,0 +1,54 @@
+﻿<files>
+  <c n="global.cs" i="50" />
+  <c n="passwords.cs" i="94" />
+  <c n="Sftp.cs" i="93" />
+  <d n="Scripts" i="51" path="C:\Users\dks\Source\repos\LibreAutomate\Scripts">
+    <d n="@Au docs" i="52">
+      <s n="Au docs.cs" i="53" />
+      <c n="AuDocs analyze.cs" i="54" />
+      <c n="AuDocs code.cs" i="55" />
+      <c n="AuDocs cookbook.cs" i="56" />
+      <c n="AuDocs other tasks.cs" i="57" />
+      <c n="AuDocs text.cs" i="58" />
+      <c n="AuDocs.cs" i="59" />
+      <n n="Readme.txt" i="60" />
+      <s n="VS goto.cs" i="61" />
+    </d>
+    <d n="@WinAPI converter" i="62">
+      <s n="WinAPI converter.cs" i="63" />
+      <c n="WinApiConverter+.cs" i="64" />
+      <c n="WinApiConverter.cs" i="65" />
+    </d>
+    <c n="Create cookbook.db.cs" i="66" />
+    <s n="Create NuGet package.cs" i="67" />
+    <d n="old" i="68">
+      <d n="Windows SDK to C#" i="69">
+        <d n="@SDK converter" i="70">
+          <c n="Classes.cs" i="71" />
+          <c n="Constants.cs" i="72" />
+          <c n="Converter.cs" i="73" />
+          <c n="Expr.cs" i="74" />
+          <c n="Functions.cs" i="75" />
+          <c n="Parameters.cs" i="76" />
+          <s n="SDK converter.cs" i="77" />
+          <c n="Tokenize.cs" i="78" />
+          <c n="Types.cs" i="79" />
+          <c n="Util.cs" i="80" />
+        </d>
+        <n n="Readme.txt" i="81" />
+        <d n="Scripts" i="82">
+          <d n="once" i="83">
+            <s n="SDK get dll names.cs" i="84" />
+            <s n="SDK get GUID.cs" i="85" />
+          </d>
+          <s n="SDK append 32-bit diff.cs" i="86" />
+          <s n="SDK create database.cs" i="87" />
+          <n n="SDK headers.h" i="88" />
+          <s n="SDK preprocessor.cs" i="89" />
+          <c n="SdkUtil.cs" i="90" />
+        </d>
+      </d>
+    </d>
+    <s n="Update version.txt.cs" i="91" />
+  </d>
+</files>

--- a/LA.Workspace.For.Scripts/files/Sftp.cs
+++ b/LA.Workspace.For.Scripts/files/Sftp.cs
@@ -1,0 +1,59 @@
+// file copied from Other\BuildEvents 2/23/25
+
+/*/ nuget -\SSH.NET; /*/
+using Microsoft.Win32;
+using Renci.SshNet;
+using System.Text.Json;
+using System.Windows.Controls;
+
+
+static class Sftp {
+	public static SftpConnectionInfo GetConnectionInfo(string where = "libreautomate.com") {
+		string rk = @"HKEY_CURRENT_USER\Software\Au";
+		var j = JsonSerializer.Deserialize<SftpConnectionInfo>(Registry.GetValue(rk, where, "{}") as string);
+		g1:
+		if (j.host.NE() || j.port == 0 || j.user.NE() || j.pass.NE()) {
+			var b = new wpfBuilder("SSH connection").WinSize(400);
+			b.R.Add("IP", out TextBox tIp, j.host).Focus(); //note: use IP. With hostname fails when using CloudFlare CDN.
+			b.R.Add("Port", out TextBox tPort, j.port.ToS());
+			b.R.Add("User", out TextBox tUser, j.user);
+			b.R.Add("Password", out TextBox tPass, j.pass.NE() ? null : Convert2.AesDecryptS(j.pass, "8470"));
+			b.R.AddOkCancel();
+			b.End();
+			if (!b.ShowDialog()) return null;
+			j.host = tIp.Text;
+			j.port = tPort.Text.ToInt();
+			j.user = tUser.Text;
+			j.pass = Convert2.AesEncryptS(tPass.Text, "8470");
+			Registry.SetValue(rk, where, JsonSerializer.Serialize(j));
+			goto g1;
+		}
+		j.pass = Convert2.AesDecryptS(j.pass, "8470");
+		return j;
+	}
+	
+	public static void ConnectAndUpload(this SftpClient ftp, string ftpDir, string localFile) {
+		ftp.Connect();
+		ftp.ChangeDirectory(ftpDir);
+		using var stream = File.OpenRead(localFile);
+		ftp.UploadFile(stream, pathname.getName(localFile));
+	}
+	
+	/// <summary>
+	/// Uploads a file to libreautomate.com (IP 194.5.156.231).
+	/// </summary>
+	/// <param name="ftpDir">Eg <c>"domains/libreautomate.com/public_html"</c></param>
+	/// <param name="localFile"></param>
+	public static void UploadToLA(string ftpDir, string localFile) {
+		var ci = Sftp.GetConnectionInfo(); if (ci == null) return;
+		using var ftp = new SftpClient(ci.host, ci.port, ci.user, ci.pass);
+		ConnectAndUpload(ftp, ftpDir, localFile);
+	}
+}
+
+record SftpConnectionInfo {
+	public string host { get; set; }
+	public int port { get; set; }
+	public string user { get; set; }
+	public string pass { get; set; }
+}

--- a/LA.Workspace.For.Scripts/files/global.cs
+++ b/LA.Workspace.For.Scripts/files/global.cs
@@ -1,0 +1,80 @@
+/// Default LibreAutomate global.cs file.  Copied from _\Default\Workspace\files\Classes on 2/23/25
+/// 
+/// Class file "global.cs" is compiled with every script etc, like with /*/ c global.cs /*/.
+/// Where don't need it, define NO_GLOBAL in meta comments: /*/ define NO_GLOBAL; /*/.
+/// You can edit this file:
+/// 	Add/remove global usings, classes, attributes.
+/// 	Add more global class files and library references: /*/ c \file.cs; r Lib.dll; /*/.
+/// 	Edit completion list filters (read more below).
+/// Note: editing this file affects all C# code files, not only files created afterwards.
+
+#if !NO_GLOBAL
+
+global using Au; //automation
+global using Au.Types; //types of parameters etc
+global using System; //.NET types used everywhere
+global using System.Collections.Generic; //List, Dictionary and other collections
+
+//less important namespaces
+global using System.Linq; //extension methods for collections
+global using System.Collections.Concurrent; //thread-safe collections
+global using System.Diagnostics; //debug [+~ ConditionalAttribute Debug Debugger EventLog FileVersionInfo Process ProcessStartInfo StackFrame StackTrace Trace]
+global using System.Globalization; //[+~ CultureInfo Number* StringInfo UnicodeCategory]
+global using System.IO; //file, directory
+global using System.IO.Compression; //zip
+global using System.Runtime.CompilerServices; //[-~ Caller* ConditionalWeakTable InternalsVisibleToAttribute MethodImpl* ModuleInitializerAttribute SkipLocalsInitAttribute Unsafe - *]
+global using System.Runtime.InteropServices; //types for Windows API etc [-~]
+global using System.Text; //[+~ Encoding Rune StringBuilder]
+global using System.Text.RegularExpressions; //[+ Regex*]
+global using System.Threading; //threads, synchronization [-~]
+global using System.Threading.Tasks; //thread pool [+~ Task]
+global using Microsoft.Win32; //[+~ Registry* SystemEvents]
+global using Au.More; //rarely used in automation scripts [-~]
+
+//The //[comments] are completion list filters. Filters are used to hide or descend some types in completion lists that contain all types.
+// 	Examples:	//[- Hide These Types], //[+ Hide Other Types], //[-~ Descend These Types], //[+~ Descend Other Types],
+// 				//[- Start* *End], //[-] (hide all), //[-~ Descend These - Hide These], //[-~ Descend These - *].
+//	What is "descend": move to the bottom, gray text, low-priority auto-select.
+//	Filters can be specified for "global using" directives in any code files included in a compilation. Also for "using" directives in current file.
+//	If a directive appears twice (eg in global.cs and in current file), is used the last filter; if no filter, previous filter is discarded.
+//	A directive can have single filter and it must be at the end of //comments in that line.
+
+//type aliases
+//global using Alias1 = Namespace1.Type1;
+
+//usings for class examples
+//global using my;
+////global using static my.Example;
+
+#endif
+
+//attributes
+#if !NO_DEFAULT_CHARSET_UNICODE
+[module: System.Runtime.InteropServices.DefaultCharSet(System.Runtime.InteropServices.CharSet.Unicode)]
+#endif
+
+//class examples
+
+//#if !NO_GLOBAL
+//namespace my;
+///// <summary>
+///// Example.
+///// </summary>
+//static class Example {
+//	/// <summary>
+//	/// Example.
+//	/// </summary>
+//	/// <param name="a"></param>
+//	/// <param name="b"></param>
+//	/// <returns></returns>
+//	/// <example>
+//	/// <code><![CDATA[
+//	/// print.it(Example.Add(2, 7));
+//	/// print.it(Add(2, 7)); //if uncommented the 'global using static my.Example;'
+//	/// ]]></code>
+//	/// </example>
+//	public static int Add(int a, int b) {
+//		return a + b;
+//	}
+//}
+//#endif

--- a/LA.Workspace.For.Scripts/files/passwords.cs
+++ b/LA.Workspace.For.Scripts/files/passwords.cs
@@ -1,0 +1,415 @@
+// file copied from https://www.libreautomate.com/forum/showthread.php?tid=7741 on 2/23/25
+
+/*/ role miniProgram; define SCRIPT; /*/
+using System.Security.Cryptography;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
+using System.Windows.Input;
+
+#if SCRIPT
+//Passwords.Save("saved", "test");
+//Passwords.Delete("Saved");
+//print.it(Passwords.Get("saved"));
+
+Passwords.ShowManagerUI();
+#endif
+
+/// <summary>
+/// Simple password manager for scripts.
+/// </summary>
+/// <remarks>
+/// In scripts, you often need to use passwords, API keys, and other kinds of credentials. This class helps to protect them. In script you use password names, not passwords directly; passwords are saved encrypted.
+/// To encrypt passwords uses a user-provided encryption key (aka master password). Saves the key encrypted using Windows data protection API, which makes it undecryptable on other computers and user accounts.
+/// Saves everything in <see cref="Folder"/>.
+/// Can be used in portable apps too; more info in <see cref="Folder"/> remarks.
+/// <para>
+/// Obviously, passwords managed by this class are not completely secure. And less secure than when using a password manager software.
+/// To use in scripts conveniently, this class saves encrypted passwords (and key) so you don't have to enter them manually each time. They can be decrypted only on the same computer/account.
+/// A determined hacker can steal the passwords if he can access that computer/account and somehow know about this class and find the saved data and this code (or just run this code). It's unlikely, but possible.
+/// Also this class does not encrypt passwords in memory, and does not clear the password string memory.
+/// But this class gives full protection from leaking passwords through script sharing or github etc.
+/// Another benefit: when you change a password, will not need to find and update it in each script that uses the password. Instead you can run this script to show the password manager UI and update the password there.
+/// </para>
+/// <para>
+/// To avoid password/key input dialogs at an inconvenient time, call any <b>Passwords</b> method at a convenient time. Or run this file (it calls <b>Passwords.ShowManagerUI</b>).
+/// </para>
+/// </remarks>
+public static class Passwords {
+    #region settings. You can edit this code.
+    
+    /// <summary>
+    /// Full path of the password manager data folder.
+    /// Default: <c>folders.ThisAppDataLocal + "Pm"</c>.
+    /// </summary>
+    /// <remarks>
+    /// In portable LA the folder is in its drive. The portable setup tool does not copy/update it, unless the path is changed like <c>folders.ThisAppDataRoaming + "Pm"</c> (the tool copies the roaming folder).
+    /// Note: the <b>folders.ThisAppDataLocal/Roaming</b> path is different if script role is <b>editorExtension</b>.
+    /// </remarks>
+    public static string Folder { get; set; } = folders.ThisAppDataLocal + "Pm";
+    
+    /// <summary>
+    /// Parameter <i>optionalEntropy</i> of <see cref="ProtectedData"/> class functions.
+    /// </summary>
+    /// <remarks>
+    /// Used when encrypting and decrypting the password encryption key. The key cannot be decrypted with different entropy than when encrypting it.
+    /// Recommended: replace the default value with a unique value of any length. It adds some more security and separates your passwords from passwords of other apps that use this class and same folder.
+    /// The names of password data and key files depend on this value. It allows multiple apps (or scripts) to save their passwords separately. Just change the default value used by your app.
+    /// </remarks>
+    static byte[] _entropy = [39, 212, 196, 74];
+    
+    /// <summary>
+    /// Edit this if want to customize the password input dialog. For example localize the text.
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="password"></param>
+    /// <param name="save">true to save the password.</param>
+    /// <returns><c>true</c> if OK.</returns>
+    static bool _PasswordInputDialog(string name, out string password, out bool save) {
+        DControls c = new() { Checkbox = "Save", IsChecked = true };
+        bool ok = dialog.showInput(out password, null, "Password for " + name, DEdit.Password, controls: c);
+        save = c.IsChecked;
+        return ok;
+    }
+    
+    /// <summary>
+    /// Edit this if want to customize the key input dialog. For example localize the text.
+    /// </summary>
+    /// <param name="key"></param>
+    /// <param name="newKey">If <c>true</c>, the user can enter a new key (there are no saved passwords). If <c>false</c>, the user must enter the same key.</param>
+    /// <returns><c>true</c> if OK.</returns>
+    static bool _KeyInputDialog(out string key, bool newKey) {
+        string info = newKey
+            ? "Please enter a key (any text) that will be used to encrypt saved passwords.\nIt will be saved encrypted for this computer/user (undecryptable elsewhere)."
+            : "Please enter the same key that was used to encrypt the saved passwords.";
+        return dialog.showInput(out key, "Password manager key", info, DEdit.Password);
+    }
+    
+    /// <summary>
+    /// Edit this if want to customize the "Delete all saved passwords?" dialog. For example localize the text.
+    /// Called when <b>_KeyInputDialog</b> returns <c>false</c> when <i>newKey</i> <c>false</c>.
+    /// </summary>
+    /// <returns><c>true</c> to delete.</returns>
+    static bool _DeletePasswordsDialog() {
+        return 1 == dialog.show("Delete all saved passwords?",
+            "Saved passwords cannot be decrypted without the key.\nIf you have lost the key, you can delete saved passwords and set a new key.\nDo you want to delete all saved passwords?",
+            "1 Delete|2 Cancel", 0, DIcon.Warning, defaultButton: 2);
+    }
+    
+    #endregion
+    
+    static string _PasswordsFile => Folder + "\\" + (_filename ??= Hash.MD5(_entropy).ToString()) + ".csv";
+    static string _filename;
+    
+    static string _KeyFile => _PasswordsFile + ".key";
+    
+    static csvTable _LoadCsv(string file = null) {
+        file ??= _PasswordsFile;
+        if (!filesystem.exists(file).File) return new() { ColumnCount = 2 };
+        var t = csvTable.load(file);
+        if (t.ColumnCount < 2) t.ColumnCount = 2;
+        return t;
+    }
+    
+    static Dictionary<string, string> _LoadDict() => _LoadCsv().ToDictionary(true, true);
+    
+    static void _SaveCsv(csvTable t) {
+        t.Save(_PasswordsFile);
+    }
+    
+    static void _SaveDict(Dictionary<string, string> d) => _SaveCsv(csvTable.fromDictionary(d));
+    
+    static byte[] _GetKey() {
+        try {
+            var data = filesystem.loadBytes(_KeyFile);
+            var r1 = ProtectedData.Unprotect(data, _entropy, DataProtectionScope.CurrentUser);
+            if (r1.Length == 16) return r1;
+        }
+        catch { }
+        
+        return _SetKey();
+    }
+    
+    static bool _KeyInputDialog2(out byte[] key, bool newKey) {
+        key = null;
+        string s = "";
+        while (s.Length < 1) {
+            if (!_KeyInputDialog(out s, newKey)) return false;
+        }
+        
+        key = Hash.MD5(s).ToArray();
+        return true;
+    }
+    
+    static byte[] _SetKey() {
+        var t = _LoadCsv();
+        bool newKey = t.RowCount == 0;
+        g1:
+        if (!_KeyInputDialog2(out var key, newKey)) { //canceled
+            if (newKey || !_DeletePasswordsDialog()) throw new OperationCanceledException();
+            filesystem.delete(_PasswordsFile);
+            filesystem.delete(_KeyFile);
+            newKey = true;
+            goto g1;
+        }
+        
+        //is data encrypted with this key?
+        if (!newKey && t.Rows.All(a => !_Decrypt(a[1], key, out _))) { //if fails to decrypt all passwords, the key is incorrect
+            500.ms();
+            goto g1;
+        }
+        
+        var p = ProtectedData.Protect(key, _entropy, DataProtectionScope.CurrentUser);
+        filesystem.saveBytes(_KeyFile, p);
+        return key;
+    }
+    
+    static bool _ChangeKey(ref byte[] key, List<_Item> a) {
+        if (!_KeyInputDialog2(out var key2, newKey: true)) return false;
+        
+        foreach (var v in a) {
+            if (_Decrypt(v.EncryptedPassword, key, out string pw))
+                v.SetNewPassword(pw, key2);
+        }
+        
+        var p = ProtectedData.Protect(key2, _entropy, DataProtectionScope.CurrentUser);
+        filesystem.saveBytes(_KeyFile, p);
+        key = key2;
+        return true;
+    }
+    
+    static string _Encrypt(string s, byte[] key = null) {
+        if (s.NE()) return "";
+        return Convert2.AesEncryptS(s, key ?? _GetKey());
+    }
+    
+    static bool _Decrypt(string s, byte[] key, out string r) {
+        if (s.NE()) r = "";
+        else {
+            try { r = Convert2.AesDecryptS(s, key); }
+            catch { r = null; return false; }
+        }
+        return true;
+    }
+    
+    //TODO: in name, replace substring <user> with user SID.
+    
+    /// <summary>
+    /// Encrypts <i>password</i> and saves in the passwords file. Can add or replace.
+    /// </summary>
+    /// <param name="name">A name for the password. Case-insensitive.</param>
+    /// <param name="password"></param>
+    /// <exception cref="OperationCanceledException">Key input dialog canceled.</exception>
+    /// <exception cref="Exception">Failed to load (if exists) or save the passwords file.</exception>
+    public static void Save(string name, string password) {
+        _Save(_LoadDict(), name, password);
+    }
+    
+    static void _Save(Dictionary<string, string> d, string name, string password) {
+        d[name] = _Encrypt(password);
+        _SaveDict(d);
+    }
+    
+    /// <summary>
+    /// Deletes one or more passwords from the passwords file.
+    /// </summary>
+    /// <param name="names">Password names. Case-insensitive.</param>
+    /// <exception cref="Exception">Failed to load (if exists) or save the passwords file.</exception>
+    public static void Delete(params string[] names) {
+        var d = _LoadDict();
+        bool deleted = false;
+        foreach (var v in names) deleted |= d.Remove(v);
+        if (deleted) _SaveDict(d);
+    }
+    
+    /// <summary>
+    /// Gets a password from the passwords file and decrypts.
+    /// If not found, shows a password input dialog and calls <see cref="Save"/> (optionally).
+    /// </summary>
+    /// <param name="name">The password's name. Case-insensitive.</param>
+    /// <returns>Password.</returns>
+    /// <exception cref="OperationCanceledException">Password input dialog canceled. Or key input dialog canceled.</exception>
+    /// <exception cref="Exception">Failed to load (if exists) or save the passwords file.</exception>
+    public static string Get(string name) {
+        var d = _LoadDict();
+        if (d.TryGetValue(name, out var s)) {
+            var key = _GetKey();
+            if (_Decrypt(s, key, out var r)) return r;
+        }
+        
+        if (!_PasswordInputDialog(name, out s, out bool save)) throw new OperationCanceledException();
+        if (save) _Save(d, name, s);
+        return s;
+    }
+    
+    /// <summary>
+    /// Gets all names.
+    /// </summary>
+    /// <exception cref="Exception">Failed to load (if exists) the passwords file.</exception>
+    /// <example>
+    /// <code><![CDATA[
+    /// //show menu with all password names
+    /// var a = Passwords.GetList();
+    /// if (a.Any()) {
+    ///     var m = new popupMenu("0cfd5f9c-8a23-4534-ad93-5af3ba8c2b41");
+    ///     foreach (var v in a) {
+    ///         m[v] = o => { print.it(Passwords.Get(v)); };
+    ///     }
+    ///     m.Show();
+    /// }
+    /// ]]></code>
+    /// </example>
+    public static string[] GetList() {
+        var d = _LoadDict();
+        return d.Keys.ToArray();
+    }
+    
+    /// <summary>
+    /// Shows a dialog window with a data grid where you can add, delete and edit names and passwords.
+    /// </summary>
+    /// <exception cref="OperationCanceledException">Key input dialog canceled.</exception>
+    /// <exception cref="Exception">Failed to load (if exists) or save the passwords file.</exception>
+    public static void ShowManagerUI(Window owner = null) {
+        var b = new wpfBuilder("Passwords").WinSize(500, 500);
+        var w = b.Window;
+        b.R.Add(out Menu menu).Margin("T-2 B0");
+        var g = new DataGrid {
+            AutoGenerateColumns = false,
+            CanUserAddRows = true,
+            VerticalGridLinesBrush = Brushes.LightGray,
+            HorizontalGridLinesBrush = Brushes.LightGray,
+        };
+        b.Row(-1).Add(g);
+        b.R.AddOkCancel();
+        b.End();
+        
+        var colName = new DataGridTextColumn {
+            Header = "Name",
+            Binding = new Binding("Name"),
+            Width = new(1, DataGridLengthUnitType.Star),
+            CanUserReorder = false
+        };
+        g.Columns.Add(colName);
+        
+        var colPw = new DataGridTextColumn {
+            Header = "Password",
+            Binding = new Binding("Password"),
+            Width = new(1, DataGridLengthUnitType.Star),
+            CanUserReorder = false
+        };
+        g.Columns.Add(colPw);
+        
+        var key = _GetKey(); //OperationCanceledException
+        var t = _LoadCsv();
+        var a = t.Rows.Select(o => new _Item(o[0], o[1], key)).ToList();
+        g.ItemsSource = a;
+        
+        //clear the displayed password placeholder text when started editing
+        g.PreparingCellForEdit += (o, e) => {
+            if (e.Column == colPw) {
+                var tb = (TextBox)e.EditingElement;
+                if (e.EditingEventArgs is not TextCompositionEventArgs) tb.Clear();
+                //tb.Foreground = tb.Background; //hide password
+            }
+        };
+        
+        //validate name when ending editing
+        g.CellEditEnding += (o, e) => {
+            if (e.EditAction == DataGridEditAction.Commit) {
+                var tb = (TextBox)e.EditingElement;
+                var s = tb.Text;
+                
+                if (s.Trim() is var s2 && s2 != s) {
+                    switch (dialog.show(null, "The texts starts or ends with spaces.", "1 Trim spaces|2 Don't trim|3 Cancel", owner: w, defaultButton: 3)) {
+                    case 3: _Cancel(); return;
+                    case 1: tb.Text = s = s2; break;
+                    }
+                }
+                
+                if (e.Column == colName) {
+                    var item = e.Row.Item as _Item;
+                    if (a.Any(v => v != item && v.Name.Eqi(s))) {
+                        dialog.show("Error", $"Name '{s}' already exists.", owner: w);
+                        _Cancel();
+                    }
+                }
+                
+                void _Cancel() {
+                    e.Cancel = true;
+                    
+                    //workaround for DataGrid bug: on Tab key starts editing next cell. Then 2 cells are in edit mode.
+                    EventHandler<DataGridBeginningEditEventArgs> eh1 = (o, e) => { e.Cancel = true; tb.Focus(); };
+                    g.BeginningEdit += eh1;
+                    timer.after(1, _ => { g.BeginningEdit -= eh1; });
+                }
+            }
+        };
+        
+        _CreateMenu();
+        
+        if (owner != null) {
+            w.Owner = owner;
+            w.ShowInTaskbar = false;
+        }
+        if (!b.ShowDialog(owner)) return;
+        
+        _SaveItems();
+        
+        void _SaveItems() {
+            var t = new csvTable { ColumnCount = 2 };
+            foreach (var v in a) t.AddRow(v.Name, v.EncryptedPassword);
+            _SaveCsv(t);
+        }
+        
+        void _CreateMenu() {
+            //File
+            var mFile = _TopItem("_Menu");
+            _Item(mFile, "Change key...", o => {
+                g.CancelEdit();
+                if (a.Any(o => o.Password == "<error>")) { //unlikely
+                    dialog.showError("Cannot change the key", "Failed to decrypt some passwords (<error>), therefore cannot encrypt them with a new key.\nEdit or delete the <error> passwords.");
+                    return;
+                }
+                if (_ChangeKey(ref key, a))
+                    _SaveItems();
+            });
+            //TODO2: UI help.
+            
+            MenuItem _Item(ItemsControl parent, string name, Action<MenuItem> click = null, string tooltip = null) {
+                var mi = new MenuItem { Header = name, ToolTip = tooltip };
+                if (click != null) mi.Click += (sender, _) => click(sender as MenuItem);
+                parent.Items.Add(mi);
+                return mi;
+            }
+            
+            MenuItem _TopItem(string name) => _Item(menu, name);
+            
+            //void _Separator(ItemsControl parent) { parent.Items.Add(new Separator()); }
+        }
+    }
+    
+    record class _Item {
+        string _pwDisplay;
+        
+        public _Item(string name, string encPw, byte[] key) {
+            Name = name;
+            EncryptedPassword = encPw;
+            if (!encPw.NE()) _pwDisplay = _Decrypt(EncryptedPassword, key, out _) ? "•…" : "<error>";
+        }
+        public _Item() { }
+        
+        public string Name { get; set; }
+        public string EncryptedPassword;
+        
+        public string Password {
+            get => _pwDisplay;
+            set => SetNewPassword(value);
+        }
+        
+        public void SetNewPassword(string s, byte[] key = null) {
+            EncryptedPassword = _Encrypt(s, key);
+            _pwDisplay = s.NE() ? null : "•…";
+        }
+    }
+}

--- a/Libraries/scintilla/win32/Scintilla.vcxproj
+++ b/Libraries/scintilla/win32/Scintilla.vcxproj
@@ -129,7 +129,8 @@
       <Command>xcopy $(TargetPath) $(SolutionDir)_\64\ /Y</Command>
     </PostBuildEvent>
     <PreLinkEvent>
-      <Command>"$(SolutionDir)Other\Programs\nircmd.exe" win close class Au.Editor.TrayNotify</Command>
+      <Command>
+      </Command>
     </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -148,7 +149,8 @@
       <Command>xcopy $(TargetPath) $(SolutionDir)_\64\ARM\ /Y</Command>
     </PostBuildEvent>
     <PreLinkEvent>
-      <Command>"$(SolutionDir)Other\Programs\nircmd.exe" win close class Au.Editor.TrayNotify</Command>
+      <Command>
+      </Command>
     </PreLinkEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Other/DocFX/_doc/docfx.json
+++ b/Other/DocFX/_doc/docfx.json
@@ -3,7 +3,7 @@
     {
       "src": [
         {
-          "src": "C:/Temp/Au/DocFX/source/",
+          "src": "../../../Other/DocPreProcessed/",
           "files": [
             "Au.csproj"
           ]
@@ -48,7 +48,7 @@
       "_disableAffix": true,
       "_disableContribution": true
     },
-    "dest": "C:/Temp/Au/DocFX/site-temp",
+    "dest": "../../../Other/DocFxProcessed",
     "globalMetadataFiles": [],
     "fileMetadataFiles": [],
     "template": [
@@ -69,4 +69,4 @@
   }
 }
 
-//https://dotnet.github.io/docfx/tutorial/docfx.exe_user_manual.html
+//http://hellosnow.github.io/docfx/tutorial/docfx.exe_user_manual.html

--- a/Scripts/@Au docs/AuDocs cookbook.cs
+++ b/Scripts/@Au docs/AuDocs cookbook.cs
@@ -2,7 +2,7 @@ using System.Xml.Linq;
 
 partial class AuDocs {
 	
-	public static void Cookbook(string docDir) {
+	public static void Cookbook(string cookbookFilesDir, string processedCookbookDir) {
 		App.Settings ??= new(); //need internetSearchUrl
 		
 		var sbToc = new StringBuilder();
@@ -11,13 +11,11 @@ partial class AuDocs {
 		regexp rxEscape = new(@"[\!\#\$\%\&\'\(\)\*\+\-\/\:\<\=\>\?\@\[\\\]\^\_\`\{\|\}\~]");
 		const string website = "https://www.libreautomate.com";
 		
-		var dirTo = docDir + @"\cookbook\";
-		if (filesystem.exists(dirTo)) filesystem.delete(Directory.GetFiles(dirTo));
+		if (filesystem.exists(processedCookbookDir)) filesystem.delete(Directory.GetFiles(processedCookbookDir));
 		
-		var dirFrom = folders.ThisAppBS + "..\\Cookbook\\files";
-		var xr = XmlUtil.LoadElem(dirFrom + ".xml");
+		var xr = XmlUtil.LoadElem(cookbookFilesDir + ".xml");
 		
-		_AddItems(xr, 1, dirFrom);
+		_AddItems(xr, 1, cookbookFilesDir);
 		
 		void _AddItems(XElement xp, int level, string path) {
 			//see PanelCookbook._Load().
@@ -41,8 +39,8 @@ partial class AuDocs {
 		}
 		
 		//print.it(sbToc.ToString());
-		filesystem.saveText(dirTo + @"\toc.md", sbToc.ToString());
-		filesystem.saveText(dirTo + @"\index.md", """
+		filesystem.saveText(processedCookbookDir + @"\toc.md", sbToc.ToString());
+		filesystem.saveText(processedCookbookDir + @"\index.md", """
 # Cookbook
 This is an online copy of the LibreAutomate C# Cookbook.
 """);
@@ -80,7 +78,7 @@ This is an online copy of the LibreAutomate C# Cookbook.
 			}
 			
 			if (test) print.it(b.ToString());
-			filesystem.saveText(dirTo + nameMd, b.ToString());
+			filesystem.saveText(processedCookbookDir + nameMd, b.ToString());
 			
 			string _Repl(RXMatch m) {
 				if (test) print.it(m);
@@ -170,7 +168,7 @@ This is an online copy of the LibreAutomate C# Cookbook.
 	}
 	
 	public static void CookbookClear(string docDir) {
-		var dirTo = docDir + @"\cookbook\";
-		filesystem.delete(Directory.GetFiles(dirTo));
+		var cookbookDocDir = docDir + @"\cookbook\";
+		filesystem.delete(Directory.GetFiles(cookbookDocDir));
 	}
 }

--- a/Scripts/@Au docs/AuDocs text.cs
+++ b/Scripts/@Au docs/AuDocs text.cs
@@ -73,7 +73,7 @@ partial class AuDocs {
 		return s;
 	}
 	
-	public void Postprocess(string siteDirTemp, string siteDir) {
+	public void Postprocess(string siteDirTemp, string siteDir, string buildDir) {
 		filesystem.delete(siteDir);
 		filesystem.createDirectory(siteDir);
 		var files = filesystem.enumFiles(siteDirTemp, flags: FEFlags.AllDescendants | FEFlags.NeedRelativePaths | FEFlags.UseRawPath).ToArray();
@@ -86,7 +86,7 @@ partial class AuDocs {
 				_ProcessJs(f.FullPath, file2);
 			} else {
 				filesystem.copy(f.FullPath, file2);
-				if (name.Eqi(@"\xrefmap.yml")) _XrefMap(f.FullPath);
+				if (name.Eqi(@"\xrefmap.yml")) _XrefMap(f.FullPath, buildDir);
 			}
 		});
 		_CreateCodeCss(siteDir);
@@ -283,7 +283,7 @@ partial class AuDocs {
 	//From xrefmap.yml extracts conceptual topics and writes to _\xrefmap.yml.
 	//Could simply copy the file, but it is ~2 MB, and we don't need api topics.
 	//Editor uses it to resolve links in code info.
-	static void _XrefMap(string file) {
+	static void _XrefMap(string file, string buildDir) {
 		var b = new StringBuilder();
 		var s = filesystem.loadText(file);
 		foreach (var m in s.RxFindAll(@"(?m)^- uid:.+\R.+\R  href: (?!api/).+\R", (RXFlags)0)) {
@@ -291,6 +291,6 @@ partial class AuDocs {
 			b.Append(m);
 		}
 		
-		filesystem.saveText(folders.ThisAppBS + "xrefmap.yml", b.ToString());
+		filesystem.saveText(buildDir + @"\xrefmap.yml", b.ToString());
 	}
 }

--- a/_/gitBinaryRestore.csv
+++ b/_/gitBinaryRestore.csv
@@ -1,1 +1,0 @@
-restore


### PR DESCRIPTION
I obviously don't know whether you are interested in this contribution.  My motivation is that I don't like the code upon which I have built something to get upgraded and thereby break what I have made unless I have lots of time on my hands.  The problem with online documentation is that it advances and no longer corresponds to what I have on my system.  So I don't much like it either.  At least not as a primary source of documentation.  So I have been hesitant to adopt LA, or really any code, where I don't have an easily accessed local copy of the documentation.

Maybe it is just me.

Anyway, in this pull request I have setup LA to use a local copy of the documentation specific to the build that is running.  To do so, I have...
1.  Created an LA workspace that just encompasses the \scripts directory.  I suspect you used LA for the whole solution in parallel with visual studio but I wanted a more circumscribed view in LA of just the scripts.  This is located in the directory \LA.Workspace.For.Scripts.  There is a readme.txt file in that directory to describe how to setup the workspace for the uninitiated (me).
2.  Rewrote the main scripts in Au docs.cs to make the information flow a little more clear (to me).
3.  Added several settings to AppSettings.cs 
4.  Added a tab in DOptions.cs for Tools --> options.  Tab is called Docs and is for adjusting the settings in AppSettings.cs.
5.  Added a private function in HelpUtils that calls docfx.exe serve if needed and shuts it down when LA exits if local documentation is turned on.

To make the code more universally useful, either the docs would need to be included in the installation program (7MB compressed) or they would have to be downloaded on demand.  Then of course docfx would need to be present (70 MB downloaded).  I did not address this as I have my copy and I am not too sure you are going to incorporate these changes.
  